### PR TITLE
Major Update

### DIFF
--- a/elementwise.py
+++ b/elementwise.py
@@ -15,79 +15,146 @@ This is a class designed to allow an operation to apply to every element of a us
 A class 'C' that wants to use this must meet a few requirements:
     - It must be iterable
     - It must be subscriptable
-    - It be able to accept a list as the only argument for a call to its constructor
+    - It must be able to accept a list as the only argument for a call to its constructor
 
-To enable the usage of the elementwise operation for a class, add the wrapper '@addElemWise' to the beginning of the class definition.
+To enable the usage of the elementwise operation for a class, add the wrapper '@elementWise.addDesc' to the beginning of the class definition.
 
 This class currently works for all binary operators, __call__, and any user-defined methods defined for all the iterates of the instance being
 operated over. It only works for positional arguments.
 '''
 
+class initInstDesc:
+    def __init__(self, cls, *posArgs):
+        if len(posArgs) == 0:
+            self.initKwParams = {}
+        else:
+            self.initKwParams = posArgs[0]
+        self.retClass = cls
+
+    def __get__(self, inst, instType=None):
+        return self.retClass(inst, **self.initKwParams)
+
+    def createDesc(name, *posArgs):
+        if len(posArgs) == 0:
+            kwParamDefaults = {}
+        else:
+            kwParamDefaults = posArgs[0]
+        def subWrap(cls):
+            initCopy = cls.__init__
+            def init(self, origInst, *posArgs, **kwArgs):
+                self.orig = origInst
+                initCopy(self, origInst, *posArgs, **kwArgs)
+            cls.__init__ = init
+            if hasattr(cls, 'addDesc'):
+                addDescCopy = cls.addDesc
+                def addDesc(otherCls):
+                    setattr(otherCls, name, initInstDesc(cls, kwParamDefaults))
+                    return addDescCopy(otherCls)
+            else:
+                def addDesc(otherCls):
+                    setattr(otherCls, name, initInstDesc(cls, kwParamDefaults))
+                    return otherCls
+            cls.addDesc = addDesc
+            if hasattr(cls, '__call__'):
+                callCopy = cls.__call__
+                def newCall(self, *posArgs, **kwArgs):
+                    if set(kwArgs.keys()).issubset(set(kwParamDefaults.keys())) and len(posArgs) == 0:
+                        newDict = dict(kwParamDefaults)
+                        newDict.update(kwArgs)
+                        return cls(self.orig, **kwArgs)
+                    else:
+                        return callCopy(self, *posArgs, **kwArgs)
+            else:
+                def newCall(self, *posArgs, **kwArgs):
+                    if set(kwArgs.keys()).issubset(set(kwParamDefaults.keys())) and len(posArgs) == 0:
+                        newDict = dict(kwParamDefaults)
+                        newDict.update(kwArgs)
+                        return cls(self.orig, **kwArgs)
+            cls.__call__ = newCall
+            return cls
+        return subWrap
+
+@initInstDesc.createDesc('e0', {'depth': 0})
+@initInstDesc.createDesc('e')
 class elementWise:
-    def __init__(self, Iter):
+    def __init__(self, Iter, depth=None):
         self.type = type(Iter)
         self.elems = list(Iter)
+        self.depth = depth
 
-    def tryFunc(element, method, pos, *posargs):
-        if len(posargs) == 0:
-            try:
-                returnVal = eval('element.e.' + method + '()')
-                if returnVal == NotImplemented:
-                    raise Exception('NotImplemented')
-            except:
-                returnVal = eval('element.' + method + '()')
-                if returnVal == NotImplemented:
-                    raise Exception('NotImplemented')
-        else:
-            arg1 = posargs[0]
-            posArgs = list(posargs)
-            posArgs.pop(0)
-            try:
-                returnVal = eval('element.e.' + method + '(arg1[pos], *posArgs)')
-                if returnVal == NotImplemented:
-                    raise Exception('NotImplemented')
-            except:
-                try:
-                    returnVal = eval('element.e.' + method + '(arg1, *posArgs)')
-                    if returnVal == NotImplemented:
-                        raise Exception('NotImplemented')
-                except:
-                    try:
-                        returnVal = eval('element.' + method + '(arg1[pos], *posArgs)')
-                        if returnVal == NotImplemented:
-                            raise Exception('NotImplemented')
-                    except:
-                        try:
-                            newMethod = method.lstrip('_')
-                            returnVal = eval('arg1[pos].__r' + newMethod + '(element)')
-                            if returnVal == NotImplemented:
-                                raise Exception('NotImplemented')
-                        except:
-                            try:
-                                returnVal = eval('element.' + method + '(arg1, *posArgs)')
-                                if returnVal == NotImplemented:
-                                    raise Exception('NotImplemented')
-                            except:
-                                newMethod = method.lstrip('_')
-                                returnVal = eval('arg1.__r' + newMethod + '(element)')
-                                if returnVal == NotImplemented:
-                                    raise Exception('NotImplemented')
-        return returnVal
-
-    def curry(self, method):
-        returnList = [lambda x, elem=elem : lambda *posArgs : elementWise.tryFunc(elem, method, i, *([x] + list(posArgs))) for i, elem in enumerate(self.elems)]
-        return self.type(returnList).e
-
-    def __getattr__(self, attr):
-        def func(*posArgs):
-            if len(posArgs) <= 1:
-                returnList = [elementWise.tryFunc(elem, attr, i, *posArgs) for i, elem in enumerate(self.elems)]
-                return self.type(returnList)
+    def chooseCanElemWise(elem, prevDepth=None):
+        try:
+            type(elem)([])
+            if prevDepth is None:
+                return elem.e
             else:
-                posArgsList = list(posArgs)
-                arg1 = posArgsList.pop(0)
-                return self.curry(attr)(arg1).e(*posArgsList)
-        return func
+                return elem.e(depth=prevDepth-1)
+        except:
+            return elem
+
+    def tryFunc(self, func, *posArgs):
+        try:
+            if all([len(arg) == len(self.elems) for arg in posArgs]):
+                returnList = [elementWise.process(func)(*([elementWise.chooseCanElemWise(elem, self.depth)] + [arg[i] for arg in posArgs])) for i, elem in enumerate(self.elems)]
+            else:
+                raise ValueError('Cannot match argument')
+        except:
+            returnList = [elementWise.process(func)(*([elementWise.chooseCanElemWise(elem, self.depth)] + list(posArgs))) for elem in self.elems]
+        return self.type(returnList)
+
+    reorderParams = lambda func, reversePermute : lambda *permutedArgs : func(*[permutedArgs[reversePermute[x]] for x in range(len(permutedArgs))])
+
+    def convertDepth0Args(arg):
+        if type(arg) is elementWise:
+            if arg.depth == 0:
+                return arg.type(arg.elems)
+        return arg
+
+    toOnlyPosArgs = lambda func, kwArgNames : lambda *posArgs : func(*posArgs[len(kwArgNames):], **{var: posArgs[i] for i, var in enumerate(sorted(kwArgNames))})
+    
+    def process(func):
+        def newFunc(*posArgs, **kwArgs):
+            if len(kwArgs) > 0:
+                return elementWise.process(elementWise.toOnlyPosArgs(func, kwArgs.keys()))(*([kwArgs[key] for key in sorted(kwArgs.keys())] + list(posArgs)))
+            else:
+                if any([type(arg) is elementWise for arg in posArgs]):
+                    ordered = True
+                    for arg, nextArg in zip(posArgs[:-1], posArgs[1:]):
+                        if type(arg) != elementWise and type(nextArg) is elementWise:
+                            ordered = False
+                            break
+                        elif type(arg) is elementWise and type(nextArg) is elementWise:
+                            if arg.depth == 0 and nextArg.depth != 0:
+                                ordered = False
+                                break
+                    if ordered:
+                        posargs = list(map(elementWise.convertDepth0Args, posArgs))
+                        arg1 = posargs.pop(0)
+                        if type(arg1) is elementWise:
+                            return arg1.tryFunc(func, *posargs)
+                        else:
+                            return func(arg1, *posargs)
+                    else:
+                        beginList, endList, middleList, beginArgs, endArgs, depth0args = [[] for i in range(6)]
+                        for i, arg in enumerate(posArgs):
+                            if type(arg) is elementWise:
+                                if arg.depth == 0:
+                                    depth0args.append(arg)
+                                    middleList.append(i)
+                                else:
+                                    beginArgs.append(arg)
+                                    beginList.append(i)
+                            else:
+                                endArgs.append(arg)
+                                endList.append(i)
+                        permuteList, permutedArgs = beginList + middleList + endList, beginArgs + depth0args + endArgs
+                        reversePermute = {y:x for x, y in enumerate(permuteList)}
+                        return elementWise.process(elementWise.reorderParams(func, reversePermute))(*permutedArgs)
+                else:
+                    return func(*posArgs)
+        return newFunc
+
+    __getattr__ = lambda self, attr : lambda *posArgs : elementWise.process(lambda x, *otherPosArgs : eval('x.' + attr + '(*otherPosArgs)'))(self, *posArgs)
 
     for operatorName in SAFE_OVERLOADABLE_OPERATORS:
         try:
@@ -95,14 +162,7 @@ class elementWise:
     method = self.__getattr__(''' + "'__" + operatorName +  "__'" + ''')
     return method(*posArgs)''')
         except Exception as err:
-            print(err)
             print(operatorName)
+            print(err)
+            pass
 
-def addElemWise(cls):
-    class newCls(cls):
-        def __getattr__(self, attr):
-            if attr == 'e':
-                return elementWise(self)
-            else:
-                return super().__getattr__(attr)
-    return newCls


### PR DESCRIPTION
Major functionality changes:
- Now supports keyword arguments
- Can now specify depth
    - To specify depth, do 'container.e(depth=specificDepth)'
    - To specify a depth of zero, you can use 'e0' instead of 'e(depth=0)'
- New system for parsing arguments when multiple elementWise arguments are called:
    - First, all the cartesian product of all the elementWise arguments is determined (in the other they were passed)
    - Then the rest of the arguments are applied to element wise to this product
Minor changes:
- The new wrapper to allow a class to support the elementWise operator is '@elementWise.addDesc'.
- The wrapper '@elementWise.process' can now be applied to any function to allow it to support the elementWise operator.
Most changes were to the implementation of the operator:
- Currying is no longer used. Instead, normal recursive calls are used for multiple elementWise arguments.
- elementWise.tryFunc has a different interface.
- A new system is used for making sure that trying to access the 'e' attribute of a container returns the elementWise version of the container. A class of general descriptors was designed to create descriptors for classes that some instance as an initial argument to create an instance of that call and re-delegate function calls to the new instance (which I will call an 'operator class'). This new class is called 'initInstDesc'. Usage:
    - To make sure you can use this descriptor for an operator class, it needs to meet the following requirement:
        - Its constructor must be able to accept a single instance as the only argument.
    - You can make multiple descriptors for an operator class.
        - To make a descriptor for the operator class, use the wrapper '@initInstDesc.createDesc(name)'.
        - To make a descriptor for the operator class with specific values for keyword arguments to its constructor, store the names of the keywords and their values in a dictionary, and call the wrapper like this: '@initInstDesc.createDesc(name, kwValsDict)'.
    - To allow the operator class to support another class, add this wrapper before the other class: 'operatorClass.addDesc'.
    - When using the descriptor, if you want to call the operator class with specific values for keyword arguments to its constructor, call the described instance with those keyword arguments, e.g.: 'operatedInst.desc(keyWord1=val1, keyWord2=val2)'.
        - You only need to do this when the values aren't the defaults for the created descriptor.